### PR TITLE
Add whitelist to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
     "> 1%",
     "last 2 versions",
     "not ie <= 8"
+  ],
+  "files": [
+    "src/heatmap.js"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-heatmapjs",
   "main": "src/heatmap.js",
-  "version": "1.4.0",
+  "version": "1.5.0-0",
   "description": "A vue directive for collecting and displaying user activity on a component",
   "author": "Brock <brock.reece@croud.co.uk>",
   "scripts": {


### PR DESCRIPTION
Instead of building a blacklist, it was easier to build a whitelist of files to be published to NPM in the package.json