### PR TITLE
Multi heatmap

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-heatmapjs",
   "main": "src/heatmap.js",
-  "version": "1.5.0-0",
+  "version": "1.6.0-0",
   "description": "A vue directive for collecting and displaying user activity on a component",
   "author": "Brock <brock.reece@croud.co.uk>",
   "scripts": {

--- a/src/heatmap.js
+++ b/src/heatmap.js
@@ -6,8 +6,6 @@ window.addEventListener('load', () => { loaded = true; });
 
 export default {
   install(Vue, options = {}) {
-    let heatmap;
-
     const addValue = (e, value) => {
       e.value = value;
       return e;
@@ -87,7 +85,7 @@ export default {
     });
 
     const loadHeatmap = async (el, binding) => {
-      heatmap = h337.create({
+      const heatmap = h337.create({
         maxOpacity: 0.6,
         radius: 50,
         blur: 0.90,


### PR DESCRIPTION
Fix `heatmap` variable scoping that is only allowing a single heatmap to work per page.

preview change in prerelease `vue-heatmapjs@1.6.0-0`